### PR TITLE
pocl 1.0 (new formula)

### DIFF
--- a/Formula/pocl.rb
+++ b/Formula/pocl.rb
@@ -1,0 +1,27 @@
+class Pocl < Formula
+  desc "MIT-licensed open source implementation of the OpenCL standard"
+  homepage "http://portablecl.org/"
+  url "http://portablecl.org/downloads/pocl-1.0.tar.gz"
+  sha256 "94bd86a2f9847c03e6c3bf8dca12af3734f8b272ffeacbc3fa8fcca58844b1d4"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+
+  # POCL 1.0 does not support LLVM 6
+  depends_on "llvm@5"
+
+  depends_on "hwloc"
+  depends_on "libtool"
+
+  option "without-test", "Skip build-time tests (not recommended)"
+  
+  def install
+    cmake_args = std_cmake_args
+    cmake_args << "-DWITH_LLVM_CONFIG=#{Formula["llvm@5"].opt_bin}/llvm-config"
+    cmake_args << "-DCMAKE_FIND_FRAMEWORK=NEVER" # Preventing LTDL_H been set to Mono's include path
+    system "cmake", ".", *cmake_args
+    system "make"
+    # system "make", "check" if build.with? "test" # Disable for now due to https://github.com/pocl/pocl/issues/412
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

This PR is a continuation to https://github.com/Homebrew/homebrew-science/pull/6503

It does not pass `brew audit` because:
 * Tests are disabled for now due to upstream bug
 * It depends on "llvm@5" instead of "llvm" because pocl 1.0 does not support llvm 6

